### PR TITLE
Fix on setup.py for my system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -611,7 +611,9 @@ class BuildExt(build_ext):
             return_type = 'void' if sys.version_info[0] <= 2 else 'PyObject*'
 
             ext.extra_compile_args.append(
-                '''-fvisibility=hidden -D'PyMODINIT_FUNC=%s__attribute__((visibility("default"))) %s ' ''' % (extern, return_type))
+                '-fvisibility=hidden')
+            ext.extra_compile_args.append(
+                '-DPyMODINIT_FUNC=%s__attribute__((visibility("default"))) %s ' % (extern, return_type))
 
     def is_debug_interpreter(self):
         """


### PR DESCRIPTION
Hi,

pip install failed on my Mac:
- Python 3.6.4
- disttools==0.1.6
-setuptools==40.8.0
- clang Apple LLVM version 9.0.0 (clang-900.0.39.2)

This allowed me to build.

Cheers,
Martha