### PR TITLE
Added space before unit in label_guinier for consistency

### DIFF
--- a/freesas/plot.py
+++ b/freesas/plot.py
@@ -83,7 +83,7 @@ def scatter_plot(data, guinier=None, ift=None,
             ax.errorbar(q, I, err, label=label_exp, capsize=0, color=exp_color, ecolor=err_color, alpha=0.5)
         else:
             ax.plot(q, I, label=label_exp, color=exp_color, alpha=0.5)
-        label_guinier += ": $R_g=$%.2f%s, $I_0=$%.2f" % (rg, unit, I0)
+        label_guinier += ": $R_g=$%.2f %s, $I_0=$%.2f" % (rg, unit, I0)
         ax.plot(q_guinier, I_guinier, label=label_guinier, color=guinier_color, linewidth=5)
 
     if ift:


### PR DESCRIPTION
The legend for the Guinier region in the Scattering Curve plot did not have a space before the unit. All other text in the plot do have a space...