### PR TITLE
Silent Matplotlib backends on MacOS for freesias

### DIFF
--- a/freesas/__init__.py
+++ b/freesas/__init__.py
@@ -56,6 +56,6 @@ project = _os.path.basename(_os.path.dirname(_os.path.abspath(__file__)))
 
 try:
     from ._version import __date__ as date  # noqa
-    from ._version import version, version_info, hexversion, strictversion  # noqa
+    from ._version import version, version_info, hexversion, strictversion, dated_version  # noqa
 except ImportError:
     raise RuntimeError("Do NOT use %s from its sources: build it and use the built version" % project)

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -52,7 +52,6 @@ def set_backend(output, format):
         @param output: Name of the specified output file
         @param format: User specified format
     """
-    from matplotlib import get_backend
     from matplotlib.pyplot import switch_backend
     if format:
         format = format.lower()

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -43,28 +43,29 @@ logger = logging.getLogger("plot_sas")
 from pathlib import Path
 
 import numpy
-import freesas
+from freesas import dated_version as freesas_version
+#import freesas
 from freesas import plot
 
-def set_backend(output, format):
+def set_backend(output: Path, outputformat: str):
     """ Explicitely set silent backend based on format or filename
         Needed on MacOS
         @param output: Name of the specified output file
         @param format: User specified format
     """
     from matplotlib.pyplot import switch_backend
-    if format:
-        format = format.lower()
+    if outputformat:
+        outputformat = outputformat.lower()
     elif len(output.suffix) > 0:
-        format = output.suffix.lower()[1:]
-    if format:
-        if format == "svg":
+        outputformat = output.suffix.lower()[1:]
+    if outputformat:
+        if outputformat == "svg":
             switch_backend("svg")
-        elif format in ["ps", "eps"]:
+        elif outputformat in ["ps", "eps"]:
             switch_backend("ps")
-        elif format == "pdf":
+        elif outputformat == "pdf":
             switch_backend("pdf")
-        elif format == "png":
+        elif outputformat == "png":
             switch_backend("agg")
 
 def parse():
@@ -75,7 +76,7 @@ def parse():
     description = "Generate typical sas plots with matplotlib"
     epilog = """freesas is an open-source implementation of a bunch of
     small angle scattering algorithms. """
-    version = "freesas.py version %s from %s" % (freesas.version, freesas.date)
+    version = "freesas.py version %s from %s" % (freesas_version.version, freesas_version.date)
     parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
     parser.add_argument("file", metavar="FILE", nargs='+', help="dat files to plot")
     parser.add_argument("-o", "--output", action='store', help="Output filename", default=None, type=Path)

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -95,7 +95,7 @@ def main():
         files = glob.glob(args.file[0])
         files.sort()
     input_len = len(files)
-    logger.debug("%s input files" % input_len)
+    logger.debug("%s input files", input_len)
     figures = []
     if len(files) > 1 and args.output:
         logger.warning("Only PDF export is possible in multi-frame mode")

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -34,9 +34,9 @@ __date__ = "14/05/2020"
 import os
 import sys
 import argparse
+import platform
 import logging
 import glob
-import platform
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("plot_sas")
 
@@ -54,19 +54,18 @@ def set_backend(output, format):
     """
     from matplotlib import get_backend
     from matplotlib.pyplot import switch_backend
-
     if format:
         format = format.lower()
     elif len(output.suffix) > 0:
         format = output.suffix.lower()[1:]
     if format:
-        if format in ["svg", "scgz"]:
+        if format == "svg":
             switch_backend("svg")
         elif format in ["ps", "eps"]:
             switch_backend("ps")
-        elif format == "pdf"
+        elif format == "pdf":
             switch_backend("pdf")
-        elif format == "png"
+        elif format == "png":
             switch_backend("agg")
 
 def parse():

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -31,12 +31,9 @@ __license__ = "MIT"
 __copyright__ = "2020, ESRF"
 __date__ = "14/05/2020"
 
-import os
-import sys
 import argparse
 import platform
 import logging
-import glob
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("plot_sas")
 
@@ -90,9 +87,9 @@ def main():
     args = parse()
     if args.verbose:
         logging.root.setLevel(logging.DEBUG)
-    files = [i for i in args.file if os.path.exists(i)]
+    files = [Path(i) for i in args.file if Path(i).exists()]
     if platform.system() == "Windows" and files == []:
-        files = glob.glob(args.file[0])
+        files = list(Path.cwd().glob(args.file[0]))
         files.sort()
     input_len = len(files)
     logger.debug("%s input files", input_len)
@@ -103,7 +100,7 @@ def main():
         import matplotlib.pyplot as plt
         raise NotImplementedError("TODO")
     if args.output:
-        if sys.platform == "darwin":
+        if platform.system() == "Darwin":
             set_backend(args.output, args.format)
     for afile in files:
         try:

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -113,8 +113,8 @@ def main():
         else:
             fig = plot.plot_all(data, filename=args.output, format=args.format)
             figures.append(fig)
-        if args.output is None:
-            fig.show()
+            if args.output is None:
+                fig.show()
     if not args.output:
         input("Press enter to quit")
 

--- a/freesas/plot.py
+++ b/freesas/plot.py
@@ -11,7 +11,7 @@ __date__ = "14/05/2020"
 import logging
 logger = logging.getLogger(__name__)
 import numpy
-from matplotlib.pyplot import subplots
+from matplotlib.pyplot import subplots, switch_backend
 
 
 def scatter_plot(data, guinier=None, ift=None,

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ except ImportError:
 
 PROJECT = "freesas"
 
-if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0] > 2:
+if "LANG" not in os.environ and platform.system() == "Darwin" and sys.version_info[0] > 2:
     print("""WARNING: the LANG environment variable is not defined,
 an utf-8 LANG is mandatory to use setup.py, you may face unexpected UnicodeError.
 export LANG=en_US.utf-8
@@ -623,7 +623,7 @@ class BuildExt(build_ext):
             args.append("-g")
 
             #On MacOS, we set the optimization level to avoid trouble with AppleClang 10
-            if sys.platform == "darwin":
+            if platform.system() == "Darwin":
                 args.append("-O0")
             # only strip asserts in release mode
             if not debug_mode:

--- a/version.py
+++ b/version.py
@@ -49,7 +49,6 @@ Thus 2.1.0a3 is hexversion 0x020100a3.
 
 """
 
-from __future__ import absolute_import, print_function, division
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -83,6 +82,10 @@ _version_info = namedtuple("version_info", ["major", "minor", "micro", "releasel
 version_info = _version_info(MAJOR, MINOR, MICRO, RELEV, SERIAL)
 
 strictversion = version = debianversion = "%d.%d.%d" % version_info[:3]
+
+_dated_version = namedtuple("dated_version", ["version", "date"])
+dated_version = _dated_version(version=version, date=date)
+
 if version_info.releaselevel != "final":
     version += "-%s%s" % version_info[-2:]
     debianversion += "~adev%i" % version_info[-1] if RELEV == "dev" else "~%s%i" % version_info[-2:]


### PR DESCRIPTION
The matplotlib backend on MacOS is not very silent, even if a figure is not shown. Setting a silent backend depending on the desired output format provides a silent  freesas also on MacOS.

While I was working on the above, I also did some refactoring. I am not sure whether the filename grep on windows works as intended, as I have no Windows machine to test...