### PR TITLE
Extended data loading for SASBDB data

### DIFF
--- a/freesas/app/auto_gpa.py
+++ b/freesas/app/auto_gpa.py
@@ -30,17 +30,17 @@ __copyright__ = "2020, ESRF"
 __date__ = "05/06/2020"
 
 import sys
-import os
 import argparse
 import logging
-import glob
 import platform
+from os import linesep
+from pathlib import Path
+from freesas import autorg
+from freesas import dated_version as freesas_version
+from freesas.sasio import load_scattering_data
+
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("auto_gpa")
-
-import numpy
-import freesas
-from freesas import autorg
 
 if sys.version_info < (3, 6):
     logger.error("This code uses F-strings and requires Python 3.6+")
@@ -51,33 +51,42 @@ def parse():
     :return: list of input files
     """
     usage = "auto_gpa.py [OPTIONS] FILES "
-    description = "Calculate the radius of gyration using Guinier Peak Analysis (Putnam 2016) for a set of scattering curves"
+    description = "Calculate the radius of gyration using Guinier" \
+                  " Peak Analysis (Putnam 2016) for a set of scattering curves"
     epilog = """auto_gpa.py is an open-source implementation of
     the autorg algorithm originately part of the ATSAS suite.
-    As this tool used a differnt theory, some results may differ 
+    As this tool used a differnt theory, some results may differ
     """
-    version = "auto_gpa.py version %s from %s" % (freesas.version, freesas.date)
-    parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
-    parser.add_argument("file", metavar="FILE", nargs='+', help="dat files to compare")
-    parser.add_argument("-o", "--output", action='store', help="Output filename", default=None, type=str)
-    parser.add_argument("-f", "--format", action='store', help="Output format: native, csv, ssf", default="native", type=str)
-    parser.add_argument("-v", "--verbose", default=0, help="switch to verbose mode", action='count')
+    version = "auto_gpa.py version %s from %s" % (freesas_version.version,
+                                                  freesas_version.date)
+    parser = argparse.ArgumentParser(usage=usage,
+                                     description=description,
+                                     epilog=epilog)
+    parser.add_argument("file", metavar="FILE", nargs='+',
+                        help="dat files to compare")
+    parser.add_argument("-o", "--output", action='store',
+                        help="Output filename", default=None, type=str)
+    parser.add_argument("-f", "--format", action='store',
+                        help="Output format: native, csv, ssf",
+                        default="native", type=str)
+    parser.add_argument("-v", "--verbose", default=0,
+                        help="switch to verbose mode", action='count')
     parser.add_argument("-V", "--version", action='version', version=version)
     return parser.parse_args()
 
 
 def main():
     args = parse()
-    if args.verbose==1:
+    if args.verbose == 1:
         logging.root.setLevel(logging.INFO)
-    elif args.verbose>=2:
+    elif args.verbose >= 2:
         logging.root.setLevel(logging.DEBUG)
-    files = [i for i in args.file if os.path.exists(i)]
+    files = [Path(i) for i in args.file if Path(i).exists()]
     if platform.system() == "Windows" and files == []:
-        files = glob.glob(args.file[0])
+        files = list(Path.cwd().glob(args.file[0]))
         files.sort()
     input_len = len(files)
-    logger.debug("%s input files" % input_len)
+    logger.debug("%s input files", input_len)
 
     if args.output:
         dst = open(args.output, "w")
@@ -85,19 +94,21 @@ def main():
         dst = sys.stdout
 
     if args.format == "csv":
-        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,Last point,Quality,Aggregated" + os.linesep)
+        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,"
+                  "Last point,Quality,Aggregated" + linesep)
 
     for afile in files:
         logger.info("Processing %s", afile)
         try:
-            data = numpy.loadtxt(afile)
+            data = load_scattering_data(afile)
         except:
             logger.error("Unable to parse file %s", afile)
         else:
             try:
                 rg = autorg.auto_gpa(data)
             except Exception as err:
-                sys.stdout.write("%s, %s: %s\n" % (afile, err.__class__.__name__, err))
+                sys.stdout.write("%s, %s: %s\n" %
+                                 (afile, err.__class__.__name__, err))
             else:
                 if args.format == "csv":
                     res = f"{afile},{rg.Rg:6.4f},{rg.sigma_Rg:6.4f},{rg.I0:6.4f},{rg.sigma_I0:6.4f},{rg.start_point:3},{rg.end_point:3},{rg.quality:6.4f},{rg.aggregated:6.4f}"
@@ -106,7 +117,7 @@ def main():
                 else:
                     res = "%s %s"%(afile, rg)
                 dst.write(res)
-                dst.write(os.linesep)
+                dst.write(linesep)
                 dst.flush()
     if args.output:
         dst.close()

--- a/freesas/app/auto_guinier.py
+++ b/freesas/app/auto_guinier.py
@@ -30,17 +30,17 @@ __copyright__ = "2020, ESRF"
 __date__ = "05/06/2020"
 
 import sys
-import os
 import argparse
 import logging
-import glob
 import platform
+from os import linesep
+from pathlib import Path
+from freesas import autorg
+from freesas import dated_version as freesas_version
+from freesas.sasio import load_scattering_data
+
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("auto_guinier")
-
-import numpy
-import freesas
-from freesas import autorg
 
 if sys.version_info < (3, 6):
     logger.error("This code uses F-strings and requires Python 3.6+")
@@ -50,34 +50,43 @@ def parse():
     """ Parse input and return list of files.
     :return: list of input files
     """
-    usage = "auto_gpa.py [OPTIONS] FILES "
-    description = "Calculate the radius of gyration using Guinier Peak Analysis (Putnam 2016) for a set of scattering curves"
+    usage = "auto_guinier.py [OPTIONS] FILES "
+    description = "Calculate the radius of gyration using linear fitting of"\
+                  "logarithmic intensities for a set of scattering curves"
     epilog = """auto_gpa.py is an open-source implementation of
     the autorg algorithm originately part of the ATSAS suite.
-    As this tool used a differnt theory, some results may differ 
+    As this tool used a differnt theory, some results may differ
     """
-    version = "auto_gpa.py version %s from %s" % (freesas.version, freesas.date)
-    parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
-    parser.add_argument("file", metavar="FILE", nargs='+', help="dat files to compare")
-    parser.add_argument("-o", "--output", action='store', help="Output filename", default=None, type=str)
-    parser.add_argument("-f", "--format", action='store', help="Output format: native, csv, ssf", default="native", type=str)
-    parser.add_argument("-v", "--verbose", default=0, help="switch to verbose mode", action='count')
+    version = "auto_guinier.py version %s from %s" % (freesas_version.version,
+                                                      freesas_version.date)
+    parser = argparse.ArgumentParser(usage=usage,
+                                     description=description,
+                                     epilog=epilog)
+    parser.add_argument("file", metavar="FILE", nargs='+',
+                        help="dat files to compare")
+    parser.add_argument("-o", "--output", action='store',
+                        help="Output filename", default=None, type=str)
+    parser.add_argument("-f", "--format", action='store',
+                        help="Output format: native, csv, ssf",
+                        default="native", type=str)
+    parser.add_argument("-v", "--verbose", default=0,
+                        help="switch to verbose mode", action='count')
     parser.add_argument("-V", "--version", action='version', version=version)
     return parser.parse_args()
 
 
 def main():
     args = parse()
-    if args.verbose==1:
+    if args.verbose == 1:
         logging.root.setLevel(logging.INFO)
-    elif args.verbose>=2:
+    elif args.verbose >= 2:
         logging.root.setLevel(logging.DEBUG)
-    files = [i for i in args.file if os.path.exists(i)]
+    files = [Path(i) for i in args.file if Path(i).exists()]
     if platform.system() == "Windows" and files == []:
-        files = glob.glob(args.file[0])
+        files = list(Path.cwd().glob(args.file[0]))
         files.sort()
     input_len = len(files)
-    logger.debug("%s input files" % input_len)
+    logger.debug("%s input files", input_len)
 
     if args.output:
         dst = open(args.output, "w")
@@ -85,19 +94,21 @@ def main():
         dst = sys.stdout
 
     if args.format == "csv":
-        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,Last point,Quality,Aggregated" + os.linesep)
+        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,Last point,"
+                  "Quality,Aggregated" + linesep)
 
     for afile in files:
         logger.info("Processing %s", afile)
         try:
-            data = numpy.loadtxt(afile)
+            data = load_scattering_data(afile)
         except:
             logger.error("Unable to parse file %s", afile)
         else:
             try:
                 rg = autorg.auto_guinier(data)
             except Exception as err:
-                sys.stdout.write("%s, %s: %s\n" % (afile, err.__class__.__name__, err))
+                sys.stdout.write("%s, %s: %s\n" %
+                                 (afile, err.__class__.__name__, err))
             else:
                 if args.format == "csv":
                     res = f"{afile},{rg.Rg:6.4f},{rg.sigma_Rg:6.4f},{rg.I0:6.4f},{rg.sigma_I0:6.4f},{rg.start_point:3},{rg.end_point:3},{rg.quality:6.4f},{rg.aggregated:6.4f}"
@@ -106,7 +117,7 @@ def main():
                 else:
                     res = "%s %s"%(afile, rg)
                 dst.write(res)
-                dst.write(os.linesep)
+                dst.write(linesep)
                 dst.flush()
     if args.output:
         dst.close()

--- a/freesas/app/autorg.py
+++ b/freesas/app/autorg.py
@@ -30,17 +30,17 @@ __copyright__ = "2017-2020, ESRF"
 __date__ = "05/06/2020"
 
 import sys
-import os
 import argparse
 import logging
-import glob
 import platform
-logging.basicConfig(level=logging.WARNING)
-logger = logging.getLogger("autorg")
-
-import numpy
-import freesas
+from os import linesep
+from pathlib import Path
 from freesas import autorg
+from freesas import dated_version as freesas_version
+from freesas.sasio import load_scattering_data
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger("auto_gpa")
 
 if sys.version_info < (3, 6):
     logger.error("This code uses F-strings and requires Python 3.6+")
@@ -51,33 +51,42 @@ def parse():
     :return: list of input files
     """
     usage = "autorg.py [OPTIONS] FILES "
-    description = "Calculate the radius of gyration using Guinier law for a set of scattering curves"
+    description = "Calculate the radius of gyration using Guinier law" \
+                  " for a set of scattering curves"
     epilog = """autorg.py is an open-source implementation of
     the autorg algorithm originately part of the ATSAS suite.
-    As this is reverse engineered, some constants and results may differ 
+    As this is reverse engineered, some constants and results may differ
     """
-    version = "autorg.py version %s from %s" % (freesas.version, freesas.date)
-    parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
-    parser.add_argument("file", metavar="FILE", nargs='+', help="dat files to compare")
-    parser.add_argument("-o", "--output", action='store', help="Output filename", default=None, type=str)
-    parser.add_argument("-f", "--format", action='store', help="Output format: native, csv, ssf", default="native", type=str)
-    parser.add_argument("-v", "--verbose", default=0, help="switch to verbose mode", action='count')
+    version = "autorg.py version %s from %s" % (freesas_version.version,
+                                                freesas_version.date)
+    parser = argparse.ArgumentParser(usage=usage,
+                                     description=description,
+                                    epilog=epilog)
+    parser.add_argument("file", metavar="FILE", nargs='+',
+                        help="dat files to compare")
+    parser.add_argument("-o", "--output", action='store',
+                        help="Output filename", default=None, type=str)
+    parser.add_argument("-f", "--format", action='store',
+                        help="Output format: native, csv, ssf",
+                        default="native", type=str)
+    parser.add_argument("-v", "--verbose", default=0,
+                        help="switch to verbose mode", action='count')
     parser.add_argument("-V", "--version", action='version', version=version)
     return parser.parse_args()
 
 
 def main():
     args = parse()
-    if args.verbose==1:
+    if args.verbose == 1:
         logging.root.setLevel(logging.INFO)
-    elif args.verbose>=2:
+    elif args.verbose >= 2:
         logging.root.setLevel(logging.DEBUG)
-    files = [i for i in args.file if os.path.exists(i)]
+    files = [Path(i) for i in args.file if Path(i).exists()]
     if platform.system() == "Windows" and files == []:
-        files = glob.glob(args.file[0])
+        files = list(Path.cwd().glob(args.file[0]))
         files.sort()
     input_len = len(files)
-    logger.debug("%s input files" % input_len)
+    logger.debug("%s input files", input_len)
 
     if args.output:
         dst = open(args.output, "w")
@@ -85,19 +94,20 @@ def main():
         dst = sys.stdout
 
     if args.format == "csv":
-        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,Last point,Quality,Aggregated" + os.linesep)
+        dst.write("File,Rg,Rg StDev,I(0),I(0) StDev,First point,Last point,Quality,Aggregated" + linesep)
 
     for afile in files:
         logger.info("Processing %s", afile)
         try:
-            data = numpy.loadtxt(afile)
+            data = load_scattering_data(afile)
         except:
             logger.error("Unable to parse file %s", afile)
         else:
             try:
                 rg = autorg.autoRg(data)
             except Exception as err:
-                sys.stdout.write("%s, %s: %s\n" % (afile, err.__class__.__name__, err))
+                sys.stdout.write("%s, %s: %s\n" %
+                                 (afile, err.__class__.__name__, err))
             else:
                 if args.format == "csv":
                     res = f"{afile},{rg.Rg:6.4f},{rg.sigma_Rg:6.4f},{rg.I0:6.4f},{rg.sigma_I0:6.4f},{rg.start_point:3},{rg.end_point:3},{rg.quality:6.4f},{rg.aggregated:6.4f}"
@@ -106,7 +116,7 @@ def main():
                 else:
                     res = "%s %s"%(afile, rg)
                 dst.write(res)
-                dst.write(os.linesep)
+                dst.write(linesep)
                 dst.flush()
     if args.output:
         dst.close()

--- a/freesas/app/cormap.py
+++ b/freesas/app/cormap.py
@@ -16,6 +16,7 @@ logger = logging.getLogger("cormap")
 import numpy
 from itertools import combinations
 from collections import namedtuple
+from freesas.sasio import load_scattering_data
 datum = namedtuple("datum", ["index", "filename", "data"])
 
 import platform
@@ -32,7 +33,7 @@ def parse():
     description = "Measure pair-wise dimilarity of spectra "
     epilog = """cormap.py is an open-source implementation of
     the cormap algorithm in datcmp (from ATSAS).
-    It does not scale the data and assume they are already scaled 
+    It does not scale the data and assume they are already scaled
     """
     version = "autorg.py version %s from %s" % (freesas.version, freesas.date)
     parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
@@ -58,7 +59,7 @@ def compare(lstfiles):
     data = []
     for i, f in enumerate(lstfiles):
         try:
-            ary = numpy.loadtxt(f)
+            ary = load_scattering_data(f)
         except ValueError as e:
             print(e)
         if ary.ndim > 1 and ary.shape[1] > 1:

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -41,7 +41,6 @@ from pathlib import Path
 
 import numpy
 from freesas import dated_version as freesas_version
-#import freesas
 from freesas import plot
 
 def set_backend(output: Path, outputformat: str):

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -71,12 +71,20 @@ def parse():
     description = "Generate typical sas plots with matplotlib"
     epilog = """freesas is an open-source implementation of a bunch of
     small angle scattering algorithms. """
-    version = "freesas.py version %s from %s" % (freesas_version.version, freesas_version.date)
-    parser = argparse.ArgumentParser(usage=usage, description=description, epilog=epilog)
-    parser.add_argument("file", metavar="FILE", nargs='+', help="dat files to plot")
-    parser.add_argument("-o", "--output", action='store', help="Output filename", default=None, type=Path)
-    parser.add_argument("-f", "--format", action='store', help="Output format: jpeg, svg, png, pdf", default=None, type=str)
-    parser.add_argument("-v", "--verbose", default=False, help="switch to verbose mode", action='store_true')
+    version = "freesas.py version %s from %s" % (freesas_version.version,
+                                                 freesas_version.date)
+    parser = argparse.ArgumentParser(usage=usage,
+                                     description=description,
+                                     epilog=epilog)
+    parser.add_argument("file", metavar="FILE", nargs='+',
+                        help="dat files to plot")
+    parser.add_argument("-o", "--output", action='store',
+                        help="Output filename", default=None, type=Path)
+    parser.add_argument("-f", "--format", action='store',
+                        help="Output format: jpeg, svg, png, pdf",
+                        default=None, type=str)
+    parser.add_argument("-v", "--verbose", default=False,
+                        help="switch to verbose mode", action='store_true')
     parser.add_argument("-V", "--version", action='version', version=version)
     return parser.parse_args()
 

--- a/freesas/app/plot_sas.py
+++ b/freesas/app/plot_sas.py
@@ -34,14 +34,13 @@ __date__ = "14/05/2020"
 import argparse
 import platform
 import logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("plot_sas")
-
 from pathlib import Path
-
-import numpy
 from freesas import dated_version as freesas_version
 from freesas import plot
+from freesas.sasio import load_scattering_data
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("plot_sas")
 
 def set_backend(output: Path, outputformat: str):
     """ Explicitely set silent backend based on format or filename
@@ -103,7 +102,7 @@ def main():
             set_backend(args.output, args.format)
     for afile in files:
         try:
-            data = numpy.loadtxt(afile)
+            data = load_scattering_data(afile)
         except:
             logger.error("Unable to parse file %s", afile)
         else:

--- a/freesas/sasio.py
+++ b/freesas/sasio.py
@@ -20,10 +20,13 @@ __date__ = "25/07/2020"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
-from typing import List
+from typing import List, Union
+from os import PathLike
 from numpy import loadtxt, array, ndarray
 
-def load_scattering_data(filename: str) -> ndarray:
+PathType = Union[PathLike, str, bytes]
+
+def load_scattering_data(filename: PathType) -> ndarray:
     """
     Load scattering data q, I, err into a numpy array.
 

--- a/freesas/sasio.py
+++ b/freesas/sasio.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: FreeSAS
+#             https://github.com/kif/freesas
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+
+"""
+Contains helper functions for loading SAS data from differents sources.
+"""
+__authors__ = ["Martha Brennich"]
+__contact__ = "martha.brennich@googlemail.com"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "25/07/2020"
+__status__ = "development"
+__docformat__ = 'restructuredtext'
+
+from typing import List
+from numpy import loadtxt, array, ndarray
+
+def load_scattering_data(filename: str) -> ndarray:
+    """
+    Load scattering data q, I, err into a numpy array.
+
+    :param filename: ASCII file, 3 column (q,I,err)
+    :return: numpy array with 3 column (q,I,err)
+    """
+    try:
+        data = loadtxt(filename)
+    except OSError:
+        raise OSError("File could not be read.")
+    except ValueError:
+        try:
+            with open(filename) as data_file:
+                text = data_file.readlines()
+        except OSError:
+            raise OSError("File could not be read.")
+        else:
+            try:
+                data = parse_ascii_data(text, number_of_columns=3)
+            except ValueError:
+                raise ValueError("File does not seem to be "
+                                 "in the format q, I, err. ")
+    return data
+
+def parse_ascii_data(input_file_text: List[str],
+                     number_of_columns: int) -> ndarray:
+    """
+    Parse data from an ascii file into an N column numpy array
+
+    :param input_file_text: List containing one line of input data per element
+    :param number_of_columns: Expected number of lines in the data file
+    :return: numpy array with 3 column (q,I,err)
+    """
+    data = []
+    for line in input_file_text:
+        split = line.split()
+        if len(split) == number_of_columns:
+            try:
+                data.append([float(x) for x in split])
+            except ValueError as err:
+                if "could not convert string to float" in err.args[0]:
+                    pass
+                else:
+                    raise
+    if data == []:
+        raise ValueError
+    data = array(data)
+    return data

--- a/freesas/test/mock_open_38.py
+++ b/freesas/test/mock_open_38.py
@@ -1,6 +1,10 @@
 """
 This is the Python 3.8 implementation of mock_open taken from
 https://github.com/python/cpython/blob/3.8/Lib/unittest/mock.py
+Hence: 
+"Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 Python Software Foundation;
+All Rights Reserved"
 """
 
 import io

--- a/freesas/test/mock_open_38.py
+++ b/freesas/test/mock_open_38.py
@@ -4,11 +4,12 @@ https://github.com/python/cpython/blob/3.8/Lib/unittest/mock.py
 """
 
 import io
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, DEFAULT
 
 
 file_spec = None
-
+#sentinel = _Sentinel()
+#DEFAULT = sentinel.DEFAULT
 
 def _to_stream(read_data):
     if isinstance(read_data, bytes):

--- a/freesas/test/mock_open_38.py
+++ b/freesas/test/mock_open_38.py
@@ -1,0 +1,93 @@
+"""
+This is the Python 3.8 implementation of mock_open taken from
+https://github.com/python/cpython/blob/3.8/Lib/unittest/mock.py
+"""
+
+import io
+from unittest.mock import MagicMock
+
+
+file_spec = None
+
+
+def _to_stream(read_data):
+    if isinstance(read_data, bytes):
+        return io.BytesIO(read_data)
+    else:
+        return io.StringIO(read_data)
+
+
+def mock_open(mock=None, read_data=''):
+    """
+    A helper function to create a mock to replace the use of `open`. It works
+    for `open` called directly or used as a context manager.
+    The `mock` argument is the mock object to configure. If `None` (the
+    default) then a `MagicMock` will be created for you, with the API limited
+    to methods or attributes available on standard file handles.
+    `read_data` is a string for the `read`, `readline` and `readlines` of the
+    file handle to return.  This is an empty string by default.
+    """
+    _read_data = _to_stream(read_data)
+    _state = [_read_data, None]
+
+    def _readlines_side_effect(*args, **kwargs):
+        if handle.readlines.return_value is not None:
+            return handle.readlines.return_value
+        return _state[0].readlines(*args, **kwargs)
+
+    def _read_side_effect(*args, **kwargs):
+        if handle.read.return_value is not None:
+            return handle.read.return_value
+        return _state[0].read(*args, **kwargs)
+
+    def _readline_side_effect(*args, **kwargs):
+        yield from _iter_side_effect()
+        while True:
+            yield _state[0].readline(*args, **kwargs)
+
+    def _iter_side_effect():
+        if handle.readline.return_value is not None:
+            while True:
+                yield handle.readline.return_value
+        for line in _state[0]:
+            yield line
+
+    def _next_side_effect():
+        if handle.readline.return_value is not None:
+            return handle.readline.return_value
+        return next(_state[0])
+
+    global file_spec
+    if file_spec is None:
+        import _io
+        file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
+
+    if mock is None:
+        mock = MagicMock(name='open', spec=open)
+
+    handle = MagicMock(spec=file_spec)
+    handle.__enter__.return_value = handle
+
+    handle.write.return_value = None
+    handle.read.return_value = None
+    handle.readline.return_value = None
+    handle.readlines.return_value = None
+
+    handle.read.side_effect = _read_side_effect
+    _state[1] = _readline_side_effect()
+    handle.readline.side_effect = _state[1]
+    handle.readlines.side_effect = _readlines_side_effect
+    handle.__iter__.side_effect = _iter_side_effect
+    handle.__next__.side_effect = _next_side_effect
+
+    def reset_data(*args, **kwargs):
+        _state[0] = _to_stream(read_data)
+        if handle.readline.side_effect == _state[1]:
+            # Only reset the side effect if the user hasn't overridden it.
+            _state[1] = _readline_side_effect()
+            handle.readline.side_effect = _state[1]
+        return DEFAULT
+
+    mock.side_effect = reset_data
+    mock.return_value = handle
+    return mock

--- a/freesas/test/test_all.py
+++ b/freesas/test/test_all.py
@@ -14,6 +14,7 @@ from . import test_distance
 from . import test_cormap
 from . import test_autorg
 from . import test_bift
+from . import test_sasio
 
 
 def suite():
@@ -24,6 +25,7 @@ def suite():
     testSuite.addTest(test_distance.suite())
     testSuite.addTest(test_cormap.suite())
     testSuite.addTest(test_autorg.suite())
+    testSuite.addTest(test_sasio.suite())
     return testSuite
 
 

--- a/freesas/test/test_sasio.py
+++ b/freesas/test/test_sasio.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+#    Project: freesas
+#             https://github.com/kif/freesas
+#
+#    Copyright (C) 2017  European Synchrotron Radiation Facility, Grenoble, France
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+__authors__ = ["Martha Brennich"]
+__license__ = "MIT"
+__date__ = "25/07/2020"
+
+import unittest
+import logging
+from numpy import array, allclose
+from ..sasio import parse_ascii_data #,load_scattering_data
+logger = logging.getLogger(__name__)
+
+
+class TestSasIO(unittest.TestCase):
+
+    def test_parse_3_ok(self):
+        """
+        Test for successful parsing of file with some invalid lines
+        """
+        file_content = ["Test data for",
+                        "file parsing",
+                        "1 1 1",
+                        "2 a 2",
+                        "3 3 3",
+                        "some stuff at the end",
+                        ]
+        expected_result = array([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]])
+        data = parse_ascii_data(file_content, number_of_columns=3)
+        self.assertTrue(allclose(data, expected_result, 1e-7),
+                        msg="3 column parse returns expected result")
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(TestSasIO("test_parse_3_ok"))
+    return test_suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/freesas/test/test_sasio.py
+++ b/freesas/test/test_sasio.py
@@ -52,10 +52,31 @@ class TestSasIO(unittest.TestCase):
         self.assertTrue(allclose(data, expected_result, 1e-7),
                         msg="3 column parse returns expected result")
 
+    def test_parse_no_data(self):
+        """
+        Test that an empty input list raises a ValueError
+        """
+        file_content = []
+        with self.assertRaises(ValueError, msg="Empty list cannot be parsed"):
+            parse_ascii_data(file_content, number_of_columns=3)
+
+    def test_parse_no_valid_data(self):
+        """
+        Test that an input list with no valid data raises a ValueError
+        """
+        file_content = ["a a a", "2 4", "3 4 5 6", "# 3 4 6"]
+        with self.assertRaises(ValueError,
+                               msg="File wiht no float float float data"
+                                   " cannot be parsed"):
+            parse_ascii_data(file_content, number_of_columns=3)
+
+
 
 def suite():
     test_suite = unittest.TestSuite()
     test_suite.addTest(TestSasIO("test_parse_3_ok"))
+    test_suite.addTest(TestSasIO("test_parse_no_data"))
+    test_suite.addTest(TestSasIO("test_parse_no_valid_data"))
     return test_suite
 
 

--- a/freesas/test/test_sasio.py
+++ b/freesas/test/test_sasio.py
@@ -30,46 +30,14 @@ __date__ = "25/07/2020"
 import unittest
 import logging
 from sys import version_info
-from unittest.mock import patch, mock_open
 from numpy import array, allclose
 from ..sasio import parse_ascii_data, load_scattering_data
-logger = logging.getLogger(__name__)
-
-#mock_open under 3.6 needs some patching up
-# Code from https://github.com/python/cpython/blob/3.8/Lib/unittest/mock.py
-if version_info.minor > 7:
-    my_mock_open = mock_open
+if version_info.minor > 6:
+    from unittest.mock import mock_open, patch
 else:
-    def my_mock_open(mock=None, read_data=''):
-        import io
-
-        def _to_stream(read_data):
-            if isinstance(read_data, bytes):
-                return io.BytesIO(read_data)
-            else:
-                return io.StringIO(read_data)
-        _read_data = _to_stream(read_data)
-        _state = [_read_data, None]
-        basic_mock = mock_open(mock, read_data)
-        handle = basic_mock.return_value
-
-        def _iter_side_effect():
-            if handle.readline.return_value is not None:
-                while True:
-                    yield handle.readline.return_value
-            for line in _state[0]:
-                yield line
-
-        def _next_side_effect():
-            if handle.readline.return_value is not None:
-                return handle.readline.return_value
-            return next(_state[0])
-
-        handle.__iter__.side_effect = _iter_side_effect
-        handle.__next__.side_effect = _next_side_effect
-
-        return basic_mock
-
+    from .mock_open_38 import mock_open
+    from unittest.mock import patch
+logger = logging.getLogger(__name__)
 
 class TestSasIO(unittest.TestCase):
 
@@ -122,7 +90,7 @@ class TestSasIO(unittest.TestCase):
                                  [2.0, 2.0, 1.0],
                                  [3.0, 3.0, 3.0]])
         file_data = "\n".join(file_content)
-        mocked_open = my_mock_open(read_data=file_data)
+        mocked_open = mock_open(read_data=file_data)
         with patch('builtins.open', mocked_open):
             with patch('numpy.DataSource.open', mocked_open):
                 data = load_scattering_data("test")
@@ -142,7 +110,7 @@ class TestSasIO(unittest.TestCase):
                                  [2.0, 2.0, 1.0],
                                  [3.0, 3.0, 3.0]])
         file_data = "\n".join(file_content)
-        mocked_open = my_mock_open(read_data=file_data)
+        mocked_open = mock_open(read_data=file_data)
         with patch('builtins.open', mocked_open):
             with patch('numpy.DataSource.open', mocked_open):
                 data = load_scattering_data("test")
@@ -163,7 +131,7 @@ class TestSasIO(unittest.TestCase):
                                  [2.0, 2.0, 1.0],
                                  [3.0, 3.0, 3.0]])
         file_data = "\n".join(file_content)
-        mocked_open = my_mock_open(read_data=file_data)
+        mocked_open = mock_open(read_data=file_data)
         with patch('builtins.open', mocked_open):
             with patch('numpy.DataSource.open', mocked_open):
                 data = load_scattering_data("test")
@@ -177,7 +145,7 @@ class TestSasIO(unittest.TestCase):
         """
         file_content = ["a a a", "2 4", "3 4 5 6", "# 3 4 6"]
         file_data = "\n".join(file_content)
-        mocked_open = my_mock_open(read_data=file_data)
+        mocked_open = mock_open(read_data=file_data)
 
         with patch('builtins.open', mocked_open):
             with patch('numpy.DataSource.open', mocked_open):

--- a/freesas/test/test_sasio.py
+++ b/freesas/test/test_sasio.py
@@ -111,9 +111,9 @@ class TestSasIO(unittest.TestCase):
                                  [3.0, 3.0, 3.0]])
         file_data = "\n".join(file_content)
         mocked_open = mock_open(read_data=file_data)
-        with patch('builtins.open', mocked_open):
-            with patch('numpy.DataSource.open', mocked_open):
-                data = load_scattering_data("test")
+        with patch('builtins.open', mocked_open), \
+             patch('numpy.DataSource.open', mocked_open):
+            data = load_scattering_data("test")
         self.assertTrue(allclose(data, expected_result, 1e-7),
                         msg="Sunny data loaded correctly")
 
@@ -132,9 +132,9 @@ class TestSasIO(unittest.TestCase):
                                  [3.0, 3.0, 3.0]])
         file_data = "\n".join(file_content)
         mocked_open = mock_open(read_data=file_data)
-        with patch('builtins.open', mocked_open):
-            with patch('numpy.DataSource.open', mocked_open):
-                data = load_scattering_data("test")
+        with patch('builtins.open', mocked_open), \
+             patch('numpy.DataSource.open', mocked_open):
+            data = load_scattering_data("test")
         self.assertTrue(allclose(data, expected_result, 1e-7),
                         msg="Sunny data loaded correctly")
 
@@ -147,12 +147,12 @@ class TestSasIO(unittest.TestCase):
         file_data = "\n".join(file_content)
         mocked_open = mock_open(read_data=file_data)
 
-        with patch('builtins.open', mocked_open):
-            with patch('numpy.DataSource.open', mocked_open):
-                with self.assertRaises(ValueError,
-                                       msg="File with no float float float "
-                                           "data cannot be loaded"):
-                    load_scattering_data("test")
+        with patch('builtins.open', mocked_open), \
+             patch('numpy.DataSource.open', mocked_open), \
+             self.assertRaises(ValueError,
+                               msg="File with no float float float "
+                                   "data cannot be loaded"):
+            load_scattering_data("test")
 
 
 def suite():

--- a/freesas/test/test_sasio.py
+++ b/freesas/test/test_sasio.py
@@ -42,16 +42,16 @@ if version_info.minor > 7:
 else:
     def my_mock_open(mock=None, read_data=''):
         import io
-        _read_data = _to_stream(read_data)
-        _state = [_read_data, None]
-        basic_mock = mock_open(mock, read_data)
-        handle = basic_mock.return_value
 
         def _to_stream(read_data):
             if isinstance(read_data, bytes):
                 return io.BytesIO(read_data)
             else:
                 return io.StringIO(read_data)
+        _read_data = _to_stream(read_data)
+        _state = [_read_data, None]
+        basic_mock = mock_open(mock, read_data)
+        handle = basic_mock.return_value
 
         def _iter_side_effect():
             if handle.readline.return_value is not None:


### PR DESCRIPTION
NumPy.loadtxt fails load data from SASBDB, probably because it does not recognize the header and footer lines. My proposed solution is to try parsing for appropriate lines if loadtxt fails with ValueError.

+ use of pathlib instead of os.path for file handling...