### PR TITLE
Fix travis for mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 
     # Install build dependencies
     - "pip3 install wheel"
-    - "pip3 --user install --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 install --user --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
     - "python3 ci/info_platform.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ addons:
         packages:
             - libhdf5-dev
 
+before_install:
+  if: os = osx
+    - python3 -m venv env
+    - source env/bin/activate
+    
 install:
     # Upgrade distribution modules
     - "pip3 install --upgrade setuptools"
@@ -44,7 +49,7 @@ install:
 
     # Install build dependencies
     - "pip3 install wheel"
-    - "pip3 install --user --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 install --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
     - "python3 ci/info_platform.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 
     # Install build dependencies
     - "pip3 install wheel"
-    - "pip3 install --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 --user install --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
     - "python3 ci/info_platform.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,8 @@ addons:
             - libhdf5-dev
 
 before_install:
-  if: os = osx
-    - python3 -m venv env
-    - source env/bin/activate
+  # activate env for mac
+  - if [[ "$OSTYPE" == "darwin"* ]]; then python3 -m venv env && source env/bin/activate; fi
     
 install:
     # Upgrade distribution modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 
     # Install build dependencies
     - "pip3 install wheel"
-    - "pip3 install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 install --trusted-host www.silx.org  --trusted-host www.edna-site.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
     - "python3 ci/info_platform.py"
@@ -56,7 +56,7 @@ install:
     - "ls dist"
 
     # Install generated wheel
-    - "pip3 install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
+    - "pip3 install --pre --find-links dist/ --trusted-host www.silx.org --trusted-host www.edna-site.org --find-links http://www.silx.org/pub/wheelhouse freesas"
 
 script:
     # Print Python info


### PR DESCRIPTION
travis on mac needs a virtual env to behave the same as the xenial jobs. This fixes it.