### PR TITLE
Some very basic tests for the CORMAP app

### DIFF
--- a/e2etest/e2etest.py
+++ b/e2etest/e2etest.py
@@ -10,7 +10,7 @@ __date__ = "11/07/2020"
 
 import sys
 import unittest
-import e2etest_freesas, e2etest_guinier_apps, e2etest_bift
+import e2etest_freesas, e2etest_guinier_apps, e2etest_bift, e2etest_cormap
 
 
 def suite():
@@ -19,6 +19,7 @@ def suite():
     test_suite.addTest(e2etest_freesas.suite())
     test_suite.addTest(e2etest_guinier_apps.suite())
     test_suite.addTest(e2etest_bift.suite())
+    test_suite.addTest(e2etest_cormap.suite())
     return test_suite
 
 

--- a/e2etest/e2etest_cormap.py
+++ b/e2etest/e2etest_cormap.py
@@ -1,0 +1,128 @@
+"""End to end tests for auto_gpa.py """
+
+__authors__ = ["Martha Brennich"]
+__license__ = "MIT"
+__date__ = "02/04/2022"
+
+import unittest
+import pathlib
+import logging
+from platform import system
+from subprocess import run, PIPE, STDOUT
+from os import linesep
+from os.path import normpath
+import codecs
+import parse
+from numpy import loadtxt
+from freesas.test.utilstests import get_datafile
+
+logger = logging.getLogger(__name__)
+
+if system() == "Windows":
+    cormapy = "cormapy.exe"
+else:
+    cormapy = "cormapy"
+
+
+class TestCormap(unittest.TestCase):
+    """End to end tests for free_bift"""
+
+    cwd = pathlib.Path.cwd()
+    bsa_filename = pathlib.Path(get_datafile("bsa_005_sub.dat"))
+
+    def test_1_input_file_results_no_correlation(self):
+        """
+        Test that cormap does not list a correlation if only one file is provided.
+        """
+
+        run_app = run(
+            [cormapy, normpath(str(self.bsa_filename))],
+            stdout=PIPE,
+            stderr=STDOUT,
+            check=True,
+        )
+
+        if system() == "Windows":
+            run_app_output = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+        else:
+            run_app_output = str(run_app.stdout, "utf-8")[:-1]
+
+        self.assertEqual(
+            run_app.returncode, 0, msg="cormapy on BM29 BSA completed well"
+        )
+
+        output_lines = run_app_output.split("\n")
+
+        corr_table_head_pos = [
+            line_number
+            for line_number, line in enumerate(output_lines)
+            if "Pr(>C)" in line
+        ][0]
+
+        self.assertEqual(
+            output_lines[corr_table_head_pos + 1],
+            "",
+            msg="Correlation table is empty",
+        )
+
+    def test_correlation_of_file_with_itself_is_1(self):
+        """
+        Test that the auto-correlation of a file is 1.
+        """
+
+        run_app = run(
+            [
+                cormapy,
+                normpath(str(self.bsa_filename)),
+                normpath(str(self.bsa_filename)),
+            ],
+            stdout=PIPE,
+            stderr=STDOUT,
+            check=True,
+        )
+
+        if system() == "Windows":
+            run_app_output = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+        else:
+            run_app_output = str(run_app.stdout, "utf-8")[:-1]
+
+        self.assertEqual(
+            run_app.returncode,
+            0,
+            msg="auto-correlation cormapy on BM29 BSA completed well",
+        )
+
+        output_lines = run_app_output.split("\n")
+
+        corr_table_head_pos = [
+            line_number
+            for line_number, line in enumerate(output_lines)
+            if "Pr(>C)" in line
+        ][0]
+
+        self.assertEqual(
+            output_lines[corr_table_head_pos + 1].split(),
+            [
+                "1",
+                "vs.",
+                "2",
+                "0",
+                "1.000000",
+            ],
+            msg="Auto-correaltion is 1",
+        )
+
+
+def suite():
+    """Build test suite for free_bift"""
+    test_suite = unittest.TestSuite()
+
+    test_suite.addTest(TestCormap("test_1_input_file_results_no_correlation"))
+    test_suite.addTest(TestCormap("test_correlation_of_file_with_itself_is_1"))
+
+    return test_suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/e2etest/e2etest_cormap.py
+++ b/e2etest/e2etest_cormap.py
@@ -11,9 +11,6 @@ from platform import system
 from subprocess import run, PIPE, STDOUT
 from os import linesep
 from os.path import normpath
-import codecs
-import parse
-from numpy import loadtxt
 from freesas.test.utilstests import get_datafile
 
 logger = logging.getLogger(__name__)
@@ -43,24 +40,28 @@ class TestCormap(unittest.TestCase):
         )
 
         if system() == "Windows":
-            run_app_output = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+            run_app_output_raw = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+            run_app_output = [
+                line.replace("\\n", "").replace("\\r", "")
+                for line in run_app_output_raw.split("\\n")[:-1]
+            ]
         else:
-            run_app_output = str(run_app.stdout, "utf-8")[:-1]
+            run_app_output_raw = str(run_app.stdout, "utf-8")[:-1]
+            run_app_output = run_app_output_raw.split(linesep)[:-1]
 
         self.assertEqual(
             run_app.returncode, 0, msg="cormapy on BM29 BSA completed well"
         )
-
-        output_lines = run_app_output.split("\n")
+        print(run_app_output)
 
         corr_table_head_pos = [
             line_number
-            for line_number, line in enumerate(output_lines)
+            for line_number, line in enumerate(run_app_output)
             if "Pr(>C)" in line
         ][0]
 
         self.assertEqual(
-            output_lines[corr_table_head_pos + 1],
+            run_app_output[corr_table_head_pos + 1],
             "",
             msg="Correlation table is empty",
         )
@@ -82,9 +83,14 @@ class TestCormap(unittest.TestCase):
         )
 
         if system() == "Windows":
-            run_app_output = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+            run_app_output_raw = str(run_app.stdout)[:-1].replace("\\\\", "\\")
+            run_app_output = [
+                line.replace("\\n", "").replace("\\r", "")
+                for line in run_app_output_raw.split("\\n")[:-1]
+            ]
         else:
-            run_app_output = str(run_app.stdout, "utf-8")[:-1]
+            run_app_output_raw = str(run_app.stdout, "utf-8")[:-1]
+            run_app_output = run_app_output_raw.split(linesep)[:-1]
 
         self.assertEqual(
             run_app.returncode,
@@ -92,16 +98,14 @@ class TestCormap(unittest.TestCase):
             msg="auto-correlation cormapy on BM29 BSA completed well",
         )
 
-        output_lines = run_app_output.split("\n")
-
         corr_table_head_pos = [
             line_number
-            for line_number, line in enumerate(output_lines)
+            for line_number, line in enumerate(run_app_output)
             if "Pr(>C)" in line
         ][0]
 
         self.assertEqual(
-            output_lines[corr_table_head_pos + 1].split(),
+            run_app_output[corr_table_head_pos + 1].split(),
             [
                 "1",
                 "vs.",

--- a/e2etest/e2etest_cormap.py
+++ b/e2etest/e2etest_cormap.py
@@ -52,7 +52,6 @@ class TestCormap(unittest.TestCase):
         self.assertEqual(
             run_app.returncode, 0, msg="cormapy on BM29 BSA completed well"
         )
-        print(run_app_output)
 
         corr_table_head_pos = [
             line_number

--- a/e2etest/e2etest_freesas.py
+++ b/e2etest/e2etest_freesas.py
@@ -33,7 +33,7 @@ import re
 import logging
 from subprocess import run, Popen, PIPE, STDOUT
 from os import linesep
-import PyPDF2
+import fitz
 from freesas.test.utilstests import get_datafile
 
 logger = logging.getLogger(__name__)
@@ -185,13 +185,15 @@ class TestFreeSAS(unittest.TestCase):
             run_freesas.returncode, 0, msg="freesas completed well"
         )
         self.assertTrue(self.TEST_PDF_NAME.exists(), msg="Found output file")
-        with open(self.TEST_PDF_NAME, "rb") as file:
-            output_pdf = PyPDF2.PdfFileReader(file)
-            self.assertEqual(
-                output_pdf.numPages, 2, msg="correct number of pages in pdf"
-            )
-            page_1_text = output_pdf.getPage(0).extractText()
-            page_2_text = output_pdf.getPage(1).extractText()
+
+        pages = []
+        with fitz.open(self.TEST_PDF_NAME) as file:
+            for page in file:
+                pages.append(page.get_text())
+
+        self.assertEqual(len(pages), 2, msg="correct number of pages in pdf")
+        page_1_text = pages[0]
+        page_2_text = pages[1]
 
         print(page_1_text)
         print(page_2_text)

--- a/e2etest/e2etest_freesas.py
+++ b/e2etest/e2etest_freesas.py
@@ -33,7 +33,7 @@ import re
 import logging
 from subprocess import run, Popen, PIPE, STDOUT
 from os import linesep
-import fitz
+import PyPDF2
 from freesas.test.utilstests import get_datafile
 
 logger = logging.getLogger(__name__)
@@ -186,18 +186,14 @@ class TestFreeSAS(unittest.TestCase):
         )
         self.assertTrue(self.TEST_PDF_NAME.exists(), msg="Found output file")
 
-        pages = []
-        with fitz.open(self.TEST_PDF_NAME) as file:
-            for page in file:
-                pages.append(page.get_text())
+        with open(self.TEST_PDF_NAME, "rb") as file:
+            output_pdf = PyPDF2.PdfFileReader(file)
+            self.assertEqual(
+                output_pdf.numPages, 2, msg="correct number of pages in pdf"
+            )
+            page_1_text = output_pdf.getPage(0).extractText()
+            page_2_text = output_pdf.getPage(1).extractText()
 
-        self.assertEqual(len(pages), 2, msg="correct number of pages in pdf")
-        page_1_text = pages[0]
-        page_2_text = pages[1]
-
-        print(page_1_text)
-        print(page_2_text)
-        print(self.bsa_filename)
         self.assertTrue(
             (str(self.bsa_filename) in page_1_text)
             ^ (str(self.bsa_filename) in page_2_text),

--- a/e2etest/e2etest_freesas.py
+++ b/e2etest/e2etest_freesas.py
@@ -35,6 +35,7 @@ from subprocess import run, Popen, PIPE, STDOUT
 from os import linesep
 import PyPDF2
 from freesas.test.utilstests import get_datafile
+
 logger = logging.getLogger(__name__)
 
 expectedTexts = {
@@ -191,6 +192,10 @@ class TestFreeSAS(unittest.TestCase):
             )
             page_1_text = output_pdf.getPage(0).extractText()
             page_2_text = output_pdf.getPage(1).extractText()
+
+        print(page_1_text)
+        print(page_2_text)
+        print(self.bsa_filename)
         self.assertTrue(
             (str(self.bsa_filename) in page_1_text)
             ^ (str(self.bsa_filename) in page_2_text),

--- a/e2etest/requirements_e2e.txt
+++ b/e2etest/requirements_e2e.txt
@@ -1,2 +1,2 @@
-PyPDF2
+pymupdf
 parse

--- a/e2etest/requirements_e2e.txt
+++ b/e2etest/requirements_e2e.txt
@@ -1,2 +1,2 @@
-pymupdf
+pyPDF2=1.26
 parse

--- a/e2etest/requirements_e2e.txt
+++ b/e2etest/requirements_e2e.txt
@@ -1,2 +1,2 @@
-pyPDF2=1.26
+pyPDF2==1.26
 parse


### PR DESCRIPTION
This adds two very basic tests to the corms app.

Unrelatedly, it fixes the pyPDF version for the e2e tests to 1.26, as 1.27 adds additional spaces.