### PR TITLE
Add `scipy` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "wheel",
     "setuptools<60.0.0",
     "numpy>=1.12",
-    "Cython>=0.21.1"
+    "Cython>=0.21.1",
+    "scipy",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
`scipy` is in `setup_requires` but it is missing in `pyproject.toml`